### PR TITLE
Fix CI gitleaks installation in security hygiene job

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -88,10 +88,17 @@ jobs:
         run: |
           pip-audit -r backend/requirements.txt
 
+      - name: Install gitleaks
+        run: |
+          wget -O gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz
+          tar -xzf gitleaks.tar.gz
+          chmod +x gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
       - name: Scan for committed secrets (gitleaks)
-        uses: gitleaks/gitleaks-action@v2
-        with:
-          args: detect --source=. --no-git --verbose -c .gitleaks.toml
+        run: |
+          gitleaks detect --source=. --no-git --verbose -c .gitleaks.toml
           
   contract-check:
     name: API contract (OpenAPI schema sync)

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -88,14 +88,11 @@ jobs:
         run: |
           pip-audit -r backend/requirements.txt
 
-      - name: Install gitleaks
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/gitleaks/gitleaks/master/scripts/install.sh | sh -s -- -b /usr/local/bin latest
-
       - name: Scan for committed secrets (gitleaks)
-        run: |
-          gitleaks detect --source="." --no-git --verbose -c .gitleaks.toml
-
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --source=. --no-git --verbose -c .gitleaks.toml
+          
   contract-check:
     name: API contract (OpenAPI schema sync)
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the security-hygiene CI workflow so gitleaks is actually available when the committed-secrets scan runs.

Included:
- update to .github/workflows/backend-ci.yml
- fix for the gitleaks installation/execution path in CI

This is a follow-up to the previously merged branch work.